### PR TITLE
Add unified service tagging (`DD_` tags)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ func routes(_ app: Application) throws {
 
     app.get { req -> String in
 
-        req.dogstatsd.increment("custom.swift.metric", tags: ["env": "prod"])
+        req.dogstatsd.increment("custom.swift.metric", tags: ["env:prod"])
 
         return "It works!"
     }

--- a/Sources/Dogstatsd/Dogstatsd.swift
+++ b/Sources/Dogstatsd/Dogstatsd.swift
@@ -60,50 +60,101 @@ public protocol DogstatsdClient {
 }
 
 extension DogstatsdClient {
-    public func count(_ name: String, value: Int64, tags: [String: String] = [:], rate: Float = 1) {
+    
+    public func count(_ name: String, value: Int64, tags: [String] = [], rate: Float = 1) {
         sender.send(metric: .count(name: name, value: value), tags: tags, rate: rate)
     }
     
-    public func increment(_ name: String, tags: [String: String] = [:], rate: Float = 1) {
+    public func increment(_ name: String, tags: [String] = [], rate: Float = 1) {
         count(name, value: 1, tags: tags, rate: rate)
     }
     
-    public func decrement(_ name: String, tags: [String: String] = [:], rate: Float = 1) {
+    public func decrement(_ name: String, tags: [String] = [], rate: Float = 1) {
         count(name, value: -1, tags: tags, rate: rate)
     }
     
-    public func gauge(_ name: String, value: Float64, tags: [String: String] = [:], rate: Float = 1) {
+    public func gauge(_ name: String, value: Float64, tags: [String] = [], rate: Float = 1) {
         sender.send(metric: .gauge(name: name, value: value), tags: tags, rate: rate)
     }
     
-    public func histogram(_ name: String, value: Float64, tags: [String: String] = [:], rate: Float = 1) {
+    public func histogram(_ name: String, value: Float64, tags: [String] = [], rate: Float = 1) {
         sender.send(metric: .histogram(name: name, value: value), tags: tags, rate: rate)
     }
     
-    public func distribution(_ name: String, value: Float64, tags: [String: String] = [:], rate: Float = 1) {
+    public func distribution(_ name: String, value: Float64, tags: [String] = [], rate: Float = 1) {
         sender.send(metric: .distribution(name: name, value: value), tags: tags, rate: rate)
     }
     
-    public func set(_ name: String, value: String, tags: [String: String] = [:], rate: Float = 1) {
+    public func set(_ name: String, value: String, tags: [String] = [], rate: Float = 1) {
         sender.send(metric: .set(name: name, value: value), tags: tags, rate: rate)
     }
     
-    public func timing(_ name: String, value: TimeInterval, tags: [String: String] = [:], rate: Float = 1) {
+    public func timing(_ name: String, value: TimeInterval, tags: [String] = [], rate: Float = 1) {
         sender.send(metric: .timing(name: name, value: value), tags: tags, rate: rate)
     }
     
     public func serviceCheck(name: String,
-                      status: ServiceCheckStatus,
-                      timestamp: Date? = nil,
-                      hostname: String? = nil,
-                      message: String? = nil,
-                      tags: [String: String] = [:]) {
+                             status: ServiceCheckStatus,
+                             timestamp: Date? = nil,
+                             hostname: String? = nil,
+                             message: String? = nil,
+                             tags: [String] = []) {
         sender.send(metric: .serviceCheck(name: name,
                                           status: status,
                                           timestamp: timestamp,
                                           hostname: hostname,
                                           message: message),
                     tags: tags,
+                    rate: 1)
+    }
+    
+    // MARK: Convenience method overloads to support a dictionary of tags
+    
+    public func count(_ name: String, value: Int64, tags: [String: String], rate: Float = 1) {
+        sender.send(metric: .count(name: name, value: value), tags: dictToList(tags: tags), rate: rate)
+    }
+    
+    public func increment(_ name: String, tags: [String: String], rate: Float = 1) {
+        count(name, value: 1, tags: dictToList(tags: tags), rate: rate)
+    }
+    
+    public func decrement(_ name: String, tags: [String: String], rate: Float = 1) {
+        count(name, value: -1, tags: dictToList(tags: tags), rate: rate)
+    }
+    
+    public func gauge(_ name: String, value: Float64, tags: [String: String], rate: Float = 1) {
+        sender.send(metric: .gauge(name: name, value: value), tags: dictToList(tags: tags), rate: rate)
+    }
+    
+    public func histogram(_ name: String, value: Float64, tags: [String: String], rate: Float = 1) {
+        sender.send(metric: .histogram(name: name, value: value), tags: dictToList(tags: tags), rate: rate)
+    }
+    
+    public func distribution(_ name: String, value: Float64, tags: [String: String], rate: Float = 1) {
+        sender.send(metric: .distribution(name: name, value: value), tags: dictToList(tags: tags), rate: rate)
+    }
+    
+    public func set(_ name: String, value: String, tags: [String: String], rate: Float = 1) {
+        sender.send(metric: .set(name: name, value: value), tags: dictToList(tags: tags), rate: rate)
+    }
+    
+    public func timing(_ name: String, value: TimeInterval, tags: [String: String], rate: Float = 1) {
+        sender.send(metric: .timing(name: name, value: value), tags: dictToList(tags: tags), rate: rate)
+    }
+    
+    
+    public func serviceCheck(name: String,
+                             status: ServiceCheckStatus,
+                             timestamp: Date? = nil,
+                             hostname: String? = nil,
+                             message: String? = nil,
+                             tags: [String: String]) {
+        sender.send(metric: .serviceCheck(name: name,
+                                          status: status,
+                                          timestamp: timestamp,
+                                          hostname: hostname,
+                                          message: message),
+                    tags: dictToList(tags: tags),
                     rate: 1)
     }
     
@@ -115,7 +166,7 @@ extension DogstatsdClient {
                priority: EventPriority? = nil,
                sourceTypeName: String? = nil,
                alertType: EventAlertType? = nil,
-               tags: [String: String] = [:]) {
+               tags: [String] = []) {
         
         sender.send(metric: .event(title: title,
                                    text: text,
@@ -129,6 +180,10 @@ extension DogstatsdClient {
                     rate: 1)
         
         
+    }
+    
+    private func dictToList(tags: [String: String]) -> [String] {
+        return tags.map { "\($0):\($1)" }
     }
 }
 

--- a/Sources/Dogstatsd/Sender.swift
+++ b/Sources/Dogstatsd/Sender.swift
@@ -5,24 +5,25 @@ import Foundation
 
 /// A dogstatsd sender interface.
 public protocol StatsdSender {
+    var globalTags: [String] { get }
+    
     func sendRaw(metric: String)
 }
 
 extension StatsdSender {
-    public func send(metric: DogstatsdMetric, tags: [String: String], rate: Float) {
+    public func send(metric: DogstatsdMetric, tags: [String], rate: Float) {
         guard shouldSample(rate: rate) else {
             return
         }
         
-        if tags.isEmpty {
+        let allTags = globalTags + tags
+        
+        if allTags.isEmpty {
             sendRaw(metric: metric.toWire)
             return
         }
             
-        let wireTags = tags.reduce("#") { reduced, kv in
-            "\(reduced)\(kv.key):\(kv.value),"
-        }.dropLast()
-        
+        let wireTags = "#\(allTags.joined(separator: ","))"
         sendRaw(metric: "\(metric.toWire)|\(wireTags)")
     }
     

--- a/Sources/Dogstatsd/VaporSender.swift
+++ b/Sources/Dogstatsd/VaporSender.swift
@@ -6,14 +6,17 @@ import Vapor
 
 /// A vapor specific non-blocking dogstatsd sender.
 class VaporSender: StatsdSender {
+    var globalTags: [String]
+    
     private let client: SocketWriteClient
     
     // Pin the event loop. this will be useful for aggregation in the future.
     private let eventLoop: EventLoop
     
-    init(client: SocketWriteClient, eventLoop: EventLoop) {
+    init(client: SocketWriteClient, eventLoop: EventLoop, globalTags: [String]) {
         self.client = client
         self.eventLoop = eventLoop
+        self.globalTags = globalTags
     }
     
     func sendRaw(metric: String) {

--- a/Sources/Tests/StatsdTests.swift
+++ b/Sources/Tests/StatsdTests.swift
@@ -6,96 +6,139 @@ import XCTest
 
 final class AppTests: XCTestCase {
     func testDogStatsd() {
-        let sender = TestDogStatsdClient()
+        let client = TestDogStatsdClient()
         
         // timing
-        sender.timing("some.timing_metric", value: 43 / 1000, tags: ["horse": "cart"])
-        XCTAssertEqual(sender.encodedMetric, "some.timing_metric:43|ms|#horse:cart")
+        client.timing("some.timing_metric", value: 43 / 1000, tags: ["horse:cart"])
+        XCTAssertEqual(client.encodedMetric, "some.timing_metric:43|ms|#horse:cart")
         
-        sender.gauge("some.gauge_metric", value: 5, tags: ["baseball": "cap"])
-        XCTAssertEqual(sender.encodedMetric, "some.gauge_metric:5.0|g|#baseball:cap")
-        
+        client.timing("some.timing_metric", value: 43 / 1000, tags: ["horse": "cart"])
+        XCTAssertEqual(client.encodedMetric, "some.timing_metric:43|ms|#horse:cart")
+       
         // gauge
-        sender.gauge("some.gauge_metric", value: 0, tags: ["baseball": "cap"])
-        XCTAssertEqual(sender.encodedMetric, "some.gauge_metric:0.0|g|#baseball:cap")
+        client.gauge("some.gauge_metric", value: 5, tags: ["baseball:cap"])
+        XCTAssertEqual(client.encodedMetric, "some.gauge_metric:5.0|g|#baseball:cap")
         
-        sender.gauge("some.gauge_metric", value: 0)
-        XCTAssertEqual(sender.encodedMetric, "some.gauge_metric:0.0|g")
+        
+        client.gauge("some.gauge_metric", value: 0, tags: ["baseball:cap"])
+        XCTAssertEqual(client.encodedMetric, "some.gauge_metric:0.0|g|#baseball:cap")
+        
+        client.gauge("some.gauge_metric", value: 0, tags: ["baseball": "cap"])
+        XCTAssertEqual(client.encodedMetric, "some.gauge_metric:0.0|g|#baseball:cap")
+        
+        client.gauge("some.gauge_metric", value: 0)
+        XCTAssertEqual(client.encodedMetric, "some.gauge_metric:0.0|g")
         
         // histogram
-        sender.histogram("some.histogram_metric", value: 109, tags: ["happy": "days"])
-        XCTAssertEqual(sender.encodedMetric, "some.histogram_metric:109.0|h|#happy:days")
+        client.histogram("some.histogram_metric", value: 109, tags: ["happy:days"])
+        XCTAssertEqual(client.encodedMetric, "some.histogram_metric:109.0|h|#happy:days")
         
-        sender.histogram("some.histogram_metric", value: 109)
-        XCTAssertEqual(sender.encodedMetric, "some.histogram_metric:109.0|h")
+        client.histogram("some.histogram_metric", value: 109, tags: ["happy": "days"])
+        XCTAssertEqual(client.encodedMetric, "some.histogram_metric:109.0|h|#happy:days")
+        
+        client.histogram("some.histogram_metric", value: 109)
+        XCTAssertEqual(client.encodedMetric, "some.histogram_metric:109.0|h")
         
         // distribution
-        sender.distribution("some.distribution_metric", value: 7, tags: ["floppy": "hat"])
-        XCTAssertEqual(sender.encodedMetric, "some.distribution_metric:7.0|d|#floppy:hat")
+        client.distribution("some.distribution_metric", value: 7, tags: ["floppy:hat"])
+        XCTAssertEqual(client.encodedMetric, "some.distribution_metric:7.0|d|#floppy:hat")
         
-        sender.distribution("some.distribution_metric", value: 7)
-        XCTAssertEqual(sender.encodedMetric, "some.distribution_metric:7.0|d")
+        client.distribution("some.distribution_metric", value: 7, tags: ["floppy": "hat"])
+        XCTAssertEqual(client.encodedMetric, "some.distribution_metric:7.0|d|#floppy:hat")
+        
+        client.distribution("some.distribution_metric", value: 7)
+        XCTAssertEqual(client.encodedMetric, "some.distribution_metric:7.0|d")
         
         // service checks
-        sender.serviceCheck(name: "neat-service",
+        client.serviceCheck(name: "neat-service",
                             status: .critical,
                             timestamp: Date(timeIntervalSince1970: 1535776860),
                             hostname: "some-host.com",
                             message: "Important message",
-                            tags: ["red": "balloon"])
-        XCTAssertEqual(sender.encodedMetric, "_sc|neat-service|2|d:1535776860|h:some-host.com|m:Important message|#red:balloon")
+                            tags: ["red:balloon"])
+        XCTAssertEqual(client.encodedMetric, "_sc|neat-service|2|d:1535776860|h:some-host.com|m:Important message|#red:balloon")
         
-        sender.serviceCheck(name: "neat-service",
+        client.serviceCheck(name: "neat-service",
                             status: .ok,
                             timestamp: Date(timeIntervalSince1970: 1535776860),
                             hostname: "some-host.com",
                             message: "Important message")
-        XCTAssertEqual(sender.encodedMetric, "_sc|neat-service|0|d:1535776860|h:some-host.com|m:Important message")
+        XCTAssertEqual(client.encodedMetric, "_sc|neat-service|0|d:1535776860|h:some-host.com|m:Important message")
         
-        sender.serviceCheck(name: "neat-service",
+        client.serviceCheck(name: "neat-service",
                             status: .ok,
                             timestamp: Date(timeIntervalSince1970: 1535776860),
                             message: "Important message",
-                            tags: ["red": "balloon"])
-        XCTAssertEqual(sender.encodedMetric, "_sc|neat-service|0|d:1535776860|m:Important message|#red:balloon")
+                            tags: ["red:balloon"])
+        XCTAssertEqual(client.encodedMetric, "_sc|neat-service|0|d:1535776860|m:Important message|#red:balloon")
         
-        sender.serviceCheck(name: "neat-service",
+        client.serviceCheck(name: "neat-service",
                             status: .warn,
                             timestamp: Date(timeIntervalSince1970: 1535776860),
                             hostname: "some-host.com",
-                            tags: ["red": "balloon"])
-        XCTAssertEqual(sender.encodedMetric, "_sc|neat-service|1|d:1535776860|h:some-host.com|#red:balloon")
+                            tags: ["red:balloon"])
+        XCTAssertEqual(client.encodedMetric, "_sc|neat-service|1|d:1535776860|h:some-host.com|#red:balloon")
         
-        sender.serviceCheck(name: "neat-service",
+        client.serviceCheck(name: "neat-service",
+                            status: .unknown,
+                            hostname: "some-host.com",
+                            message: "Important message",
+                            tags: ["red:balloon"])
+        XCTAssertEqual(client.encodedMetric, "_sc|neat-service|3|h:some-host.com|m:Important message|#red:balloon")
+        
+        client.serviceCheck(name: "neat-service",
                             status: .unknown,
                             hostname: "some-host.com",
                             message: "Important message",
                             tags: ["red": "balloon"])
-        XCTAssertEqual(sender.encodedMetric, "_sc|neat-service|3|h:some-host.com|m:Important message|#red:balloon")
+        XCTAssertEqual(client.encodedMetric, "_sc|neat-service|3|h:some-host.com|m:Important message|#red:balloon")
         
         // count
-        sender.increment("some.count")
-        XCTAssertEqual(sender.encodedMetric, "some.count:1|c")
+        client.increment("some.count")
+        XCTAssertEqual(client.encodedMetric, "some.count:1|c")
         
-        sender.decrement("some.count")
-        XCTAssertEqual(sender.encodedMetric, "some.count:-1|c")
+        client.decrement("some.count")
+        XCTAssertEqual(client.encodedMetric, "some.count:-1|c")
         
-        sender.count("some.count", value: 123)
-        XCTAssertEqual(sender.encodedMetric, "some.count:123|c")
+        client.count("some.count", value: 123)
+        XCTAssertEqual(client.encodedMetric, "some.count:123|c")
         
-        sender.count("some.count", value: 123, tags: ["some": "tag"])
-        XCTAssertEqual(sender.encodedMetric, "some.count:123|c|#some:tag")
+        client.count("some.count", value: 123, tags: ["some:tag"])
+        XCTAssertEqual(client.encodedMetric, "some.count:123|c|#some:tag")
+        
+        client.count("some.count", value: 123, tags: ["some": "tag"])
+        XCTAssertEqual(client.encodedMetric, "some.count:123|c|#some:tag")
         
         // set
-        sender.set("set", value: "foo")
-        XCTAssertEqual(sender.encodedMetric, "set:foo|s")
+        client.set("set", value: "foo")
+        XCTAssertEqual(client.encodedMetric, "set:foo|s")
         
-        sender.set("set", value: "123", tags: ["some": "tag"])
-        XCTAssertEqual(sender.encodedMetric, "set:123|s|#some:tag")
+        client.set("set", value: "123", tags: ["some:tag"])
+        XCTAssertEqual(client.encodedMetric, "set:123|s|#some:tag")
+        
+        client.set("set", value: "123", tags: ["some": "tag"])
+        XCTAssertEqual(client.encodedMetric, "set:123|s|#some:tag")
+    }
+    
+    func testGloalTags() {
+        let client = TestDogStatsdClient()
+        client.testSender.globalTags = ["foo:bar"]
+        client.increment("some.count")
+        XCTAssertEqual(client.encodedMetric, "some.count:1|c|#foo:bar")
+        
+        client.testSender.globalTags = ["foo:bar,abc:123"]
+        client.increment("some.count")
+        XCTAssertEqual(client.encodedMetric, "some.count:1|c|#foo:bar,abc:123")
+        
+        client.testSender.globalTags = ["foo:bar,abc:123"]
+        client.increment("some.count", tags: ["some:tag"])
+        XCTAssertEqual(client.encodedMetric, "some.count:1|c|#foo:bar,abc:123,some:tag")
     }
 }
 
 class TestStatsdSender: StatsdSender {
+    var globalTags: [String] = []
+    
     var encodedMetric: String = ""
     
     func sendRaw(metric: String) {

--- a/Sources/Tests/StatsdTests.swift
+++ b/Sources/Tests/StatsdTests.swift
@@ -120,7 +120,7 @@ final class AppTests: XCTestCase {
         XCTAssertEqual(client.encodedMetric, "set:123|s|#some:tag")
     }
     
-    func testGloalTags() {
+    func testGlobalTags() {
         let client = TestDogStatsdClient()
         client.testSender.globalTags = ["foo:bar"]
         client.increment("some.count")

--- a/Sources/Tests/VaporIntegrationTests.swift
+++ b/Sources/Tests/VaporIntegrationTests.swift
@@ -29,5 +29,32 @@ final class VaporIntegrationTests: XCTestCase {
         app.dogstatsd.config = .disabled
         app.dogstatsd.count("test", value: 1)
     }
+    
+    func testGlobalTags() throws {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+        
+        XCTAssertEqual(app.dogstatsd.globalTags, [])
+        
+        setenv("DD_ENV", "prod", 1)
+        XCTAssertEqual(app.dogstatsd.globalTags, ["env:prod"])
+        
+        setenv("DD_VERSION", "1.2.3", 1)
+        XCTAssertEqual(app.dogstatsd.globalTags.count, 2)
+        XCTAssertTrue(app.dogstatsd.globalTags.contains("version:1.2.3"))
+        
+        setenv("DD_SERVICE", "myService", 1)
+        XCTAssertEqual(app.dogstatsd.globalTags.count, 3)
+        XCTAssertTrue(app.dogstatsd.globalTags.contains("service:myService"))
+        
+        setenv("DD_ENTITY_ID", "12345", 1)
+        XCTAssertEqual(app.dogstatsd.globalTags.count, 4)
+        XCTAssertTrue(app.dogstatsd.globalTags.contains("dd.internal.entity_id:12345"))
+        
+        setenv("DD_ENV", "", 1)
+        setenv("DD_VERSION", "", 1)
+        setenv("DD_SERVICE", "", 1)
+        setenv("DD_ENTITY_ID", "", 1)
+    }
 }
 

--- a/Sources/Tests/VaporIntegrationTests.swift
+++ b/Sources/Tests/VaporIntegrationTests.swift
@@ -32,7 +32,13 @@ final class VaporIntegrationTests: XCTestCase {
     
     func testGlobalTags() throws {
         let app = Application(.testing)
-        defer { app.shutdown() }
+        defer {
+            setenv("DD_ENV", "", 1)
+            setenv("DD_VERSION", "", 1)
+            setenv("DD_SERVICE", "", 1)
+            setenv("DD_ENTITY_ID", "", 1)
+            app.shutdown()
+        }
         
         XCTAssertEqual(app.dogstatsd.globalTags, [])
         
@@ -51,10 +57,7 @@ final class VaporIntegrationTests: XCTestCase {
         XCTAssertEqual(app.dogstatsd.globalTags.count, 4)
         XCTAssertTrue(app.dogstatsd.globalTags.contains("dd.internal.entity_id:12345"))
         
-        setenv("DD_ENV", "", 1)
-        setenv("DD_VERSION", "", 1)
-        setenv("DD_SERVICE", "", 1)
-        setenv("DD_ENTITY_ID", "", 1)
+       
     }
 }
 


### PR DESCRIPTION
Adds support for `DD_` tags for unified service tagging. 

Also refactors how tags are handled. previously tags were treated as a dictionary which is not totally correct since: 
1. it made it difficult to supply tags that are not a key/value format (which is supported by dogstatsd)
2. it allowed conflicting tag keys which is also supported by dogstatsd since tags are just strings. 

Now tags are treated as a list of strings. 

The old interface is preserved for compatibility and convenience. 