### PR TITLE
Update CODEOWNERS to remove documentation owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,5 +5,3 @@
 
 *                     @DataDog/agent-metric-pipelines
 
-# Documentation
-*.md                  @DataDog/documentation


### PR DESCRIPTION
Remove CODEOWNERS entry for documentation files. Please use AI/other tools for grammar checks on documentation for this repo. Reach out to me or in #documenation if you have questions.